### PR TITLE
Fix webpack path polyfill configuration

### DIFF
--- a/.ym/configs/webpack.config.base.ts
+++ b/.ym/configs/webpack.config.base.ts
@@ -47,6 +47,9 @@ const configuration: webpack.Configuration = {
     modules: [webpackPaths.srcPath, 'node_modules'],
     // There is no need to add aliases here, the paths in tsconfig get mirrored
     plugins: [new TsconfigPathsPlugins()],
+    fallback: {
+      path: require.resolve('path-browserify'),
+    },
   },
 
   plugins: [

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "electron-updater": "^6.2.1",
     "imagemin": "^9.0.0",
     "imagemin-svgo": "^11.0.1",
+    "path-browserify": "^1.0.1",
     "png-to-ico": "^2.1.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Add polyfill for 'path' module in webpack configuration.

* Add `path-browserify` to the `dependencies` section in `package.json`.
* Add `resolve.fallback` configuration for the 'path' module to use `path-browserify` in `.ym/configs/webpack.config.base.ts`.

